### PR TITLE
Upload Lambda functions from S3

### DIFF
--- a/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaCreateFunctionTask.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/AWSLambdaCreateFunctionTask.java
@@ -60,7 +60,10 @@ public class AWSLambdaCreateFunctionTask extends ConventionTask {
 	
 	@Getter @Setter
 	private File zipFile;
-	
+
+	@Getter @Setter
+	private S3File s3File;
+
 	@Getter
 	private CreateFunctionResult createFunctionResult;
 
@@ -76,25 +79,43 @@ public class AWSLambdaCreateFunctionTask extends ConventionTask {
 		String functionName = getFunctionName();
 		
 		if (functionName == null) throw new GradleException("functionName is required");
-		
+
+		File zipFile = getZipFile();
+		S3File s3File = getS3File();
+
+		if ((zipFile == null && s3File == null) || (zipFile != null && s3File != null)) {
+			throw new GradleException("exactly one of zipFile or s3File is required");
+		}
+
 		AWSLambdaPluginExtension ext = getProject().getExtensions().getByType(AWSLambdaPluginExtension.class);
 		AWSLambda lambda = ext.getClient();
-		
-		try (RandomAccessFile raf = new RandomAccessFile(getZipFile(), "r");
-				FileChannel channel = raf.getChannel()) {
-			MappedByteBuffer buffer = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size());
-			buffer.load();
-			CreateFunctionRequest request = new CreateFunctionRequest()
-				.withFunctionName(getFunctionName())
-				.withRuntime(getRuntime())
-				.withRole(getRole())
-				.withHandler(getHandler())
-				.withDescription(getFunctionDescription())
-				.withTimeout(getTimeout())
-				.withMemorySize(getMemorySize())
-				.withCode(new FunctionCode().withZipFile(buffer));
-			createFunctionResult = lambda.createFunction(request);
-			getLogger().info("Create Lambda function requested: {}", createFunctionResult.getFunctionArn());
+
+		FunctionCode functionCode;
+		if (zipFile != null) {
+			try (RandomAccessFile raf = new RandomAccessFile(getZipFile(), "r");
+				 FileChannel channel = raf.getChannel()) {
+				MappedByteBuffer buffer = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size());
+				buffer.load();
+				functionCode = new FunctionCode().withZipFile(buffer);
+			}
+		} else {
+			// assume s3File is not null
+			s3File.validate();
+			functionCode = new FunctionCode()
+					.withS3Bucket(s3File.getBucketName())
+					.withS3Key(s3File.getKey())
+					.withS3ObjectVersion(s3File.getObjectVersion());
 		}
+		CreateFunctionRequest request = new CreateFunctionRequest()
+			.withFunctionName(getFunctionName())
+			.withRuntime(getRuntime())
+			.withRole(getRole())
+			.withHandler(getHandler())
+			.withDescription(getFunctionDescription())
+			.withTimeout(getTimeout())
+			.withMemorySize(getMemorySize())
+			.withCode(functionCode);
+		createFunctionResult = lambda.createFunction(request);
+		getLogger().info("Create Lambda function requested: {}", createFunctionResult.getFunctionArn());
 	}
 }

--- a/src/main/java/jp/classmethod/aws/gradle/lambda/S3File.java
+++ b/src/main/java/jp/classmethod/aws/gradle/lambda/S3File.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2015 Classmethod, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.classmethod.aws.gradle.lambda;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.gradle.api.GradleException;
+
+public class S3File {
+    @Getter @Setter
+    private String bucketName;
+
+    @Getter @Setter
+    private String key;
+
+    @Getter @Setter
+    private String objectVersion;
+
+    /**
+     * Validates that both bucketName and key are provided.
+     */
+    public void validate() {
+        boolean missingBucketName = bucketName == null || bucketName.trim().isEmpty();
+        boolean missingKey = key == null || key.trim().isEmpty();
+        if (missingBucketName || missingKey) {
+            throw new GradleException("bucketName and key are required for an S3File");
+        }
+    }
+}


### PR DESCRIPTION
Like the poster of #19, I also have a need for uploading Lambda functions from S3. I added a helper class, `S3File`, that allows you to specify the `bucketName`, `key` and `objectVersion` for the target file and modified the existing Lambda tasks that accept a `zipFile` parameter so they also accept an `s3File` parameter.

The tasks require exactly one of those two properties to be configured, generating an error if neither or both are specified.

Hopefully you can merge this in and publish soon! Thanks for all the work you've done on this, the plugin has been extremely useful so far.