### PR TITLE
Update AwsPluginExtension.java

### DIFF
--- a/src/main/java/jp/classmethod/aws/gradle/AwsPluginExtension.java
+++ b/src/main/java/jp/classmethod/aws/gradle/AwsPluginExtension.java
@@ -99,6 +99,9 @@ public class AwsPluginExtension {
 		
 		AWSCredentialsProvider credentialsProvider = newCredentialsProvider(profileName);
 		if (this.proxyHost != null && this.proxyPort > 0) {
+			if (config == null) {
+				config = new ClientConfiguration();
+			}
 			config.setProxyHost(this.proxyHost);
 			config.setProxyPort(this.proxyPort);
 		}


### PR DESCRIPTION
All the plug in extensions use a "null" config object, this breaks any attempt to set up a proxy.