### PR TITLE
Update guava

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,8 @@
 #groovyVersion=2.3.7
 lombokVersion=1.16.2
 awsJavaSdkVersion=1.11.267
-guavaVersion=18.0
+# android variant is compatible with JDK 7
+guavaVersion=26.0-android
 sparWingsVersion=0.16
 
 junitVersion=4.12


### PR DESCRIPTION

Update guava version.

Use 26.0-android for JDK7 compatibility and gradle compatibility.
https://github.com/gradle/gradle/blob/v5.3.1/gradle/dependencies.gradle#L59